### PR TITLE
flexibilize types for partial_trace

### DIFF
--- a/src/math_util.jl
+++ b/src/math_util.jl
@@ -212,7 +212,9 @@ julia> partial_trace(ρ1⊗ρ2, [2, 2], [1])
  0.2  0.6
 ```
 """
-function partial_trace(ρ::Matrix, sys_dim::AbstractVector{Int}, dim_2_keep::AbstractVector{Int})
+partial_trace(ρ::AbstractMatrix, sys_dim::AbstractVector{<:Integer}, dim_2_keep::Integer) = partial_trace(ρ,sys_dim,[dim_2_keep])
+
+function partial_trace(ρ::AbstractMatrix, sys_dim::AbstractVector{<:Integer}, dim_2_keep::AbstractVector{<:Integer})
     size(ρ, 1) != size(ρ, 2) && throw(ArgumentError("ρ is not a square matrix."))
     prod(sys_dim) != size(ρ, 1) && throw(ArgumentError("System dimensions do not multiply to density matrix dimension."))
 
@@ -226,7 +228,7 @@ function partial_trace(ρ::Matrix, sys_dim::AbstractVector{Int}, dim_2_keep::Abs
 	re_dim[dim_2_trace] .= 1
 	tr_dim = copy(sys_dim)
 	tr_dim[dim_2_keep] .= 1
-	res = zeros(ComplexF64, re_dim..., re_dim...)
+	res = zeros(typeof(first(ρ)), re_dim..., re_dim...)
 	for I in CartesianIndices(size(res))
 		for k in CartesianIndices((tr_dim...,))
 			delta = CartesianIndex(k, k)

--- a/src/math_util.jl
+++ b/src/math_util.jl
@@ -228,7 +228,7 @@ function partial_trace(ρ::AbstractMatrix, sys_dim::AbstractVector{<:Integer}, d
 	re_dim[dim_2_trace] .= 1
 	tr_dim = copy(sys_dim)
 	tr_dim[dim_2_keep] .= 1
-	res = zeros(typeof(first(ρ)), re_dim..., re_dim...)
+	res = zeros(eltype(ρ), re_dim..., re_dim...)
 	for I in CartesianIndices(size(res))
 		for k in CartesianIndices((tr_dim...,))
 			delta = CartesianIndex(k, k)


### PR DESCRIPTION
Currently partial_trace does not accept Hermitian or Symmetric matrices, and always returns a ComplexF64 result, independent of the type of the input. This PR fixes both issues. I'm also adding a convenience method to allow calling it with `dim_2_keep` being a integer instead of a vector.

I hope you find it useful.